### PR TITLE
extract `OUTPUTS(2)` as `selfOut` in buyback contract branch

### DIFF
--- a/contracts/bank/buyback.es
+++ b/contracts/bank/buyback.es
@@ -82,6 +82,7 @@
     // starting copying from oracle pool contract
     val minStartHeight = HEIGHT - $epochLength
     val poolIn = INPUTS(0)
+    val selfOut = OUTPUTS(2)
 
     def isValidDataPoint(b: Box) = if (b.R6[Long].isDefined) {
         b.creationInfo._1    >= minStartHeight &&
@@ -97,9 +98,9 @@
     val properGiving =  poolIn.tokens(0)._1 == fromBase64("$oracleNFT") &&
                         OUTPUTS(0).tokens(1)._2 >= poolIn.tokens(1)._2 + selfGort - rewardEmitted
 
-    val giveback = OUTPUTS(2).tokens(0) == SELF.tokens(0) &&
-                   OUTPUTS(2).propositionBytes == SELF.propositionBytes &&
-                   SELF.value == OUTPUTS(2).value &&
+    val giveback = selfOut.tokens(0) == SELF.tokens(0) &&
+                   selfOut.propositionBytes == SELF.propositionBytes &&
+                   SELF.value == selfOut.value &&
                    properGiving
 
     sigmaProp(giveback)


### PR DESCRIPTION
for readability and to be inline with other branches;