### PR TITLE
Add DeepWiki badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 This repository contains everything related to Dexy stablecoin protocol and its testnet and mainnet deployments.
 
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/kushti/dexy-stable)
+
 ## Contents
 
 * [Whitepaper](paper/dexy.pdf)


### PR DESCRIPTION
Added a badge link to DeepWiki for Dexy stablecoin.

This will keep the DeepWiki site refreshed 1x per week without any manual activity.