### PR TITLE
UIP-001: Balancing the Interventions

### DIFF
--- a/contracts/bank/intervention.es
+++ b/contracts/bank/intervention.es
@@ -2,7 +2,7 @@
   // Intervention script. It encodes intervention action, where the bank is buying back Dexy tokens from the LP to
   // restore the peg in the LP.
   //
-  // Parameters: intervention happens every T = 360 blocks if Dexy token price in the LP is <= 98% of oracle price.
+  // Parameters: intervention happens every T = 180 blocks if Dexy token price in the LP is <= 98% of oracle price (UIP-001).
   //
   // This box: Intervention box
   //
@@ -38,7 +38,7 @@
 
   val lastIntervention = SELF.creationInfo._1
   val buffer = 5 // error margin in height
-  val T = 360 // from paper, gap between two interventions
+  val T = 180 // gap between two interventions (UIP-001: doubled frequency)
   val T_int = 20 // blocks after which a trigger swap event can be completed, provided rate has not crossed oracle pool rate
 
   val bankNFT = fromBase64("$bankNFT")
@@ -111,7 +111,7 @@
     val validTracking = trackingHeight < HEIGHT - T_int // at least T_int blocks have passed since the tracking started
 
     val validMaxSpending = lpReservesXOutBigInt * 1000 <= oracleRateXy * lpReservesYOut * 995  &&   // new rate must be <= 99.5 * oracle rate
-                           deltaBankErgs <= bankBoxIn.value / 100 // no more than 1% of reserves spent per intervention
+                           deltaBankErgs <= lpReservesXIn / 200 // no more than 0.5% of LP reserves spent per intervention (UIP-001)
 
     // dexy price
     val price = lpBoxIn.value / lpBoxIn.tokens(2)._2


### PR DESCRIPTION
## Summary

Implements **UIP-001: Balancing the Interventions** as specified in `Uips/UIP-001-balancing-interventions.md`.

## Problem

When ERG price drops rapidly on exchanges, traders can front-run bank interventions by buying USE tokens from the LP in anticipation. This exploits information asymmetry and drains reserves—the more aggressive the intervention, the greater the reserve losses.

## Solution

This PR implements three changes to the intervention mechanism:

1. **Change intervention basis**: Calculate intervention amount from LP reserves instead of bank reserves, making each intervention predictable and preventing disproportionate interventions when bank/LP balances differ significantly

2. **Reduce intervention size**: 1% → 0.5% of LP reserves

3. **Increase intervention frequency**: 360 blocks → 180 blocks (2x frequency)

The same total ERG commitment is distributed more evenly over time through smaller, more frequent interventions, reducing front-running impact while maintaining market support.

## Test plan
- [ ] InterventionSpec tests pass
- [ ] Review intervention timing logic
- [ ] Review spending cap calculation against LP reserves

> Re-opened from #7 (closed due to fork deletion)